### PR TITLE
Remove the `persistent` option passed to `application:env_set/4`

### DIFF
--- a/src/rabbit_trust_store_app.erl
+++ b/src/rabbit_trust_store_app.erl
@@ -34,8 +34,7 @@ change_SSL_options() ->
             Before = [],
             edit(Before);
         {ok, Before} when is_list(Before) ->
-            ok = application:set_env(rabbit,
-                initial_SSL_options, Before, [{persistent, true}]),
+            ok = application:set_env(rabbit, initial_SSL_options, Before),
             edit(Before)
     end,
     ok = application:set_env(rabbit,


### PR DESCRIPTION
This isn't available on Erlang R16B03, making broker start fail, so
remove this option since it is not needed.

Resolves https://github.com/rabbitmq/rabbitmq-trust-store/issues/13.