### PR TITLE
Ensure that a replaced certificate with the same name is picked up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .sw?
+*.orig
 .*.sw?
 *.beam
 .erlang.mk/


### PR DESCRIPTION
- add test for replacing cert with same name
- disable use of ssl session cache
- gitignore

Fixes #23 