### PR TITLE
Validate the peer in a presented certificate chain

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROJECT = rabbitmq_trust_store
 
 ## We need the Cowboy's test utilities
-TEST_DEPS = rabbit amqp_client ct_helper 
+TEST_DEPS = rabbit amqp_client ct_helper
 dep_ct_helper = git https://github.com/extend/ct_helper.git master
 
 DEP_PLUGINS = rabbit_common/mk/rabbitmq-plugin.mk

--- a/test/system_SUITE.erl
+++ b/test/system_SUITE.erl
@@ -289,7 +289,7 @@ validate_chain_without_whitelisted1(Config) ->
                                                      {key, Key} | cfg()], 1),
 
     %% When: Rabbit validates paths
-    %% Then: a client presenting the whitelisted certificate `CertUntrusted` and `RootUntrusted`
+    %% Then: a client presenting the non-whitelisted certificate `CertUntrusted` and `RootUntrusted`
     %% is rejected 
     {error, ?SERVER_REJECT_CLIENT} =
         amqp_connection:start(#amqp_params_network{host = Host,


### PR DESCRIPTION
Fixes #34 

There are few moderately invasive changes to how whitelisting works, specifically for the scenario when a client presents a chain. In this case we handle the whitelist check in the `partial_chain` function that is called before the path validation iterates over each included certs and calling `verify_fun`. To do this I had to export the `is_whitelisted` function and if the peer is whitelisted treat it's immediate CA (in the included chain) as a trusted 'anchor' during path validation.