### PR TITLE
Certificate change detection if the file provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ and a refresh interval:
 Setting `refresh_interval` to `0` seconds will disable automatic refresh.
 
 Certificates are distinguished by their **filenames**, file modification time and
-a certificate hash.
+the hash of file contents.
 
 #### Installing a Certificate
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,8 @@ and a refresh interval:
 
 Setting `refresh_interval` to `0` seconds will disable automatic refresh.
 
-Certificates are distinguished by their **filenames** and file modification time.
+Certificates are distinguished by their **filenames**, file modification time and
+a certificate hash.
 
 #### Installing a Certificate
 

--- a/src/rabbit_trust_store_file_provider.erl
+++ b/src/rabbit_trust_store_file_provider.erl
@@ -8,37 +8,21 @@
 
 -define(DIRECTORY_OR_FILE_NAME_EXISTS, eexist).
 
--record(directory_state, {
-    directory_path,
-    directory_change_time}).
-
 -type cert_id() :: {FileName :: string(), ChangeTime :: integer()}.
 
 -spec list_certs(Config :: list())
     -> no_change | {ok, [{cert_id(), list()}], State}
-    when State :: #directory_state{}.
+    when State :: nostate.
 list_certs(Config) ->
     Path = directory_path(Config),
-    NewChangeTime = modification_time(Path),
     Certs = list_certs_0(Path),
-    {ok, Certs, #directory_state{directory_path = Path,
-                                 directory_change_time = NewChangeTime}}.
+    {ok, Certs, nostate}.
 
 -spec list_certs(Config :: list(), State)
     -> no_change | {ok, [{cert_id(), list()}], State}
-    when State :: #directory_state{}.
-list_certs(Config, #directory_state{directory_path = DirPath,
-                                    directory_change_time = ChangeTime}) ->
-    Path = directory_path(Config, DirPath),
-    NewChangeTime = modification_time(Path),
-    case NewChangeTime > ChangeTime of
-        false ->
-            no_change;
-        true  ->
-            Certs = list_certs_0(Path),
-            {ok, Certs, #directory_state{directory_path = Path,
-                                         directory_change_time = NewChangeTime}}
-    end.
+    when State :: nostate.
+list_certs(Config, _) ->
+    list_certs(Config).
 
 -spec load_cert(cert_id(), list(), Config :: list())
     -> {ok, Cert :: public_key:der_encoded()}.

--- a/src/rabbit_trust_store_file_provider.erl
+++ b/src/rabbit_trust_store_file_provider.erl
@@ -49,7 +49,9 @@ list_certs_0(Path) ->
     lists:map(
         fun(FileName) ->
             AbsName = filename:absname(FileName, Path),
-            CertId = {FileName, modification_time(AbsName), file_hash(AbsName)},
+            CertId = {FileName,
+                      modification_time(AbsName),
+                      file_content_hash(AbsName)},
             {CertId, [{name, FileName}]}
         end,
         FileNames).
@@ -58,7 +60,7 @@ modification_time(Path) ->
     {ok, Info} = file:read_file_info(Path, [{time, posix}]),
     Info#file_info.mtime.
 
-file_hash(Path) ->
+file_content_hash(Path) ->
     {ok, Data} = file:read_file(Path),
     erlang:phash2(Data).
 


### PR DESCRIPTION
Do not use directory change time and use file content hash to ensure all file changes are detected.

Fixes #58