### PR TITLE
Correct field name for json response

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ HTTP provider loads certificates via HTTP(S) from remote server.
 
 The server should have following API:
 
-- `GET <root>` - list certificates in JSON format: `{"certificates": [{"id": <id>, "url": <url>}, ...]}`
-- `GET <root>/<url>` - download PEM encoded certificate.
+- `GET <root>` - list certificates in JSON format: `{"certificates": [{"id": <id>, "path": <url>}, ...]}`
+- `GET <root>/<path>` - download PEM encoded certificate.
 
 Where `<root>` is a configured certificate path, `<id>` - unique certificate identifier,
-`<url>` - relative certificate path to load it from server.
+`<path>` - relative certificate path to load it from server.
 
 Configuration of the HTTP provider:
 


### PR DESCRIPTION
For the HTTP provider, the documentation incorrectly specified the field name of the relative certificate path to on server as "url". 
The correct field name according to the code is "path".