### PR TITLE
Be more defensive when refreshing certificates

### DIFF
--- a/src/rabbit_trust_store.erl
+++ b/src/rabbit_trust_store.erl
@@ -259,7 +259,7 @@ list_certs(Provider, Config, ProviderState) ->
 update_certs([], _Provider, _Config) ->
     ok;
 update_certs(CertsList, Provider, Config) ->
-    rabbit_log:debug("Updating ~s fetched trust store certificates", [length(CertsList)]),
+    rabbit_log:debug("Updating ~p fetched trust store certificates", [length(CertsList)]),
     OldCertIds = get_old_cert_ids(Provider),
     {NewCertIds, _} = lists:unzip(CertsList),
 

--- a/src/rabbit_trust_store.erl
+++ b/src/rabbit_trust_store.erl
@@ -146,10 +146,10 @@ init([]) ->
         Interval  >  0 ->
             erlang:send_after(Interval, erlang:self(), refresh)
     end,
-    {ok,
-     #state{
-      providers_state = ProvidersState,
-      refresh_interval = Interval}}.
+    State = #state{
+        providers_state = ProvidersState,
+        refresh_interval = Interval},
+    {ok, State}.
 
 handle_call(mode, _, St) ->
     {reply, mode(St), St};
@@ -165,10 +165,18 @@ handle_cast(_, St) ->
 
 handle_info(refresh, #state{refresh_interval = Interval,
                             providers_state = ProvidersState} = St) ->
-    Config = application:get_all_env(rabbitmq_trust_store),
-    NewProvidersState = refresh_certs(Config, ProvidersState),
-    erlang:send_after(Interval, erlang:self(), refresh),
-    {noreply, St#state{providers_state = NewProvidersState}};
+        Config = application:get_all_env(rabbitmq_trust_store),
+        try
+            rabbit_log:error("Trust store will attempt to refresh certificates..."),
+            NewProvidersState = refresh_certs(Config, ProvidersState),
+            {noreply, St#state{providers_state = NewProvidersState}}
+        catch
+            _:Error  ->
+                rabbit_log:error("Failed to refresh certificates: ~p", [Error]),
+                {noreply, St#state{providers_state = ProvidersState}}
+        after
+            erlang:send_after(Interval, erlang:self(), refresh)
+        end;
 handle_info(_, St) ->
     {noreply, St}.
 
@@ -227,8 +235,13 @@ refresh_certs(Config, State) ->
 refresh_provider_certs(Provider, Config, ProviderState) ->
     case list_certs(Provider, Config, ProviderState) of
         no_change ->
+            rabbit_log:debug("Trust store provider reported no certificate changes"),
+            ProviderState;
+        ok ->
+            rabbit_log:debug("Trust store provider reported no certificate changes"),
             ProviderState;
         {ok, CertsList, NewProviderState} ->
+            rabbit_log:debug("Trust store listed certificates: ~p", [CertsList]),
             update_certs(CertsList, Provider, Config),
             NewProviderState;
         {error, Reason} ->
@@ -243,7 +256,10 @@ list_certs(Provider, Config, nostate) ->
 list_certs(Provider, Config, ProviderState) ->
     Provider:list_certs(Config, ProviderState).
 
+update_certs([], _Provider, _Config) ->
+    ok;
 update_certs(CertsList, Provider, Config) ->
+    rabbit_log:debug("Updating ~s fetched trust store certificates", [length(CertsList)]),
     OldCertIds = get_old_cert_ids(Provider),
     {NewCertIds, _} = lists:unzip(CertsList),
 

--- a/src/rabbit_trust_store.erl
+++ b/src/rabbit_trust_store.erl
@@ -256,8 +256,6 @@ list_certs(Provider, Config, nostate) ->
 list_certs(Provider, Config, ProviderState) ->
     Provider:list_certs(Config, ProviderState).
 
-update_certs([], _Provider, _Config) ->
-    ok;
 update_certs(CertsList, Provider, Config) ->
     rabbit_log:debug("Updating ~p fetched trust store certificates", [length(CertsList)]),
     OldCertIds = get_old_cert_ids(Provider),

--- a/src/rabbit_trust_store_app.erl
+++ b/src/rabbit_trust_store_app.erl
@@ -10,7 +10,7 @@
 %%
 %% The Original Code is RabbitMQ.
 %%
-%% Copyright (c) 2007-2017 Pivotal Software, Inc.  All rights reserved.
+%% Copyright (c) 2007-2019 Pivotal Software, Inc.  All rights reserved.
 %%
 
 -module(rabbit_trust_store_app).
@@ -20,7 +20,7 @@
 -export([start/2, stop/1]).
 
 -rabbit_boot_step({rabbit_trust_store, [
-    {description, "Change necessary SSL options."},
+    {description, "Overrides TLS options in take RabbitMQ trust store into account"},
     {mfa, {?MODULE, change_SSL_options, []}},
     {cleanup, {?MODULE, revert_SSL_options, []}},
     %% {requires, ...},

--- a/src/rabbit_trust_store_sup.erl
+++ b/src/rabbit_trust_store_sup.erl
@@ -30,7 +30,18 @@ start_link() ->
 %% ...
 
 init([]) ->
-    {ok,
-     {{one_for_one, 1, 5},
-      [{trust_store, {rabbit_trust_store, start_link, []},
-        permanent, timer:seconds(5), worker, [rabbit_trust_store]}]}}.
+    Flags = #{strategy => one_for_one,
+              intensity => 1,
+              period => 1},
+    ChildSpecs = [
+        #{
+            id => trust_store,
+            start => {rabbit_trust_store, start_link, []},
+            restart => permanent,
+            shutdown => timer:seconds(15),
+            type => worker,
+            modules => [rabbit_trust_store]
+        }
+    ],
+
+    {ok, {Flags, ChildSpecs}}.

--- a/src/rabbit_trust_store_sup.erl
+++ b/src/rabbit_trust_store_sup.erl
@@ -31,7 +31,7 @@ start_link() ->
 
 init([]) ->
     Flags = #{strategy => one_for_one,
-              intensity => 1,
+              intensity => 10,
               period => 1},
     ChildSpecs = [
         #{


### PR DESCRIPTION
Closes #73.

Note that I concluded that adding integration tests is not worth the effort in this case. Here's why:

 * [trust-store-http](https://github.com/rabbitmq/trust-store-http) were updated to return invalid JSON
 * Integrating one more group that starts a node configured to talk to that new endpoint is trivial
 * Unfortunately, asserting that clients can connect is not possible since the endpoint would never return any valid certificates
 * Switching endpoint at runtime seems to be not worth the time investment for a basic error handling change in one provider

Pair: @pjk25.